### PR TITLE
Missing InfluxDBClientError import

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -9,6 +9,7 @@ This class is for generating Telegraf dashboards from Influxdb.
 """
 
 from influxdb import InfluxDBClusterClient
+from influxdb.exceptions import InfluxDBClientError
 import json
 import argparse
 from jinja2 import Environment, FileSystemLoader


### PR DESCRIPTION
This is needed at least in influxdb version 2.12.0
